### PR TITLE
es: configurable sniff timeout

### DIFF
--- a/invenio_ext/es.py
+++ b/invenio_ext/es.py
@@ -62,6 +62,8 @@ def setup_app(app):
 
     hosts = app.config.get('ES_HOSTS', None)
 
+    sniff_timeout = app.config.get('ES_SNIFF_TIMEOUT', 10)
+
     def get_host_info(node_info, host):
         """Simple callback that takes the node info from `/_cluster/nodes` and a
         parsed connection information and return the connection information.
@@ -90,7 +92,7 @@ def setup_app(app):
         sniff_on_start=True,
         sniff_on_connection_fail=True,
         sniffer_timeout=60,
-        sniff_timeout=10,
+        sniff_timeout=sniff_timeout,
         retry_on_timeout=True,
         host_info_callback=get_host_info
     )


### PR DESCRIPTION
- NEW Adds a new configuration variable: ES_SNIFF_TIMEOUT defaulted
  to 10, to allow adjusting the Elasticsearch sniff timeout on slow
  or busy systems.

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
