### PR TITLE
sentry: improved support for Celery

### DIFF
--- a/invenio_ext/version.py
+++ b/invenio_ext/version.py
@@ -28,4 +28,4 @@ This file is imported by ``invenio_ext.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.3.3.dev20160122"
+__version__ = "0.3.3.dev20160125"


### PR DESCRIPTION
- Improves support for Celery with Sentry, by following recipe in
  https://github.com/getsentry/raven-python/issues/427.
  Now frames from exceptions captured in Celery are available in Sentry.
- NOTE: this implementation still causes duplicates entries in
  Sentry.

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
